### PR TITLE
Remove enforce of template compiling

### DIFF
--- a/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
+++ b/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
@@ -55,11 +55,13 @@ sub _init {
         %{$args{template_options} || {}},
     );
 
-    $config{COMPILE_DIR} //= $dir || do {
-      my $tmpdir = File::Spec->catdir(File::Spec->tmpdir, "ttr$<");
-      mkdir $tmpdir unless -d $tmpdir;
-      $tmpdir;
-    };
+    if ( !exists( $config{COMPILE_DIR} ) ) {
+        $config{COMPILE_DIR} //= $dir || do {
+          my $tmpdir = File::Spec->catdir(File::Spec->tmpdir, "ttr$<");
+          mkdir $tmpdir unless -d $tmpdir;
+          $tmpdir;
+        };
+    }
 
     $config{LOAD_TEMPLATES} =
       [Mojolicious::Plugin::TtRenderer::Provider->new(%config, renderer => $app->renderer)]


### PR DESCRIPTION
Hello,

Currently this Engine forces the Template to compile even if the app explicitly tell it not to do so.
From Template module documentation:
https://metacpan.org/pod/Template#COMPILE_DIR
```
COMPILE_DIR
Root of directory in which compiled template files should be written (default: undef - don't compile).
```

Even if you don't accept this PR can you provide a way to skip template compilation?

Regards,
Dinis