### PR TITLE
Release controller

### DIFF
--- a/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
+++ b/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
@@ -94,7 +94,6 @@ sub _render {
     my @params = ({%{$c->stash}, c => $c, h => $helper}, $output, {binmode => ':utf8'});
     my $provider = $self->tt->{SERVICE}->{CONTEXT}->{LOAD_TEMPLATES}->[0];
     $provider->options($options);
-    $provider->ctx($c);
 
     my $ok = do {
         if (defined $inline) {
@@ -173,7 +172,6 @@ sub new {
 }
 
 sub renderer      { @_ > 1 ? weaken($_[0]->{renderer} = $_[1]) : $_[0]->{renderer} }
-sub ctx           { @_ > 1 ? weaken($_[0]->{ctx}      = $_[1]) : $_[0]->{ctx} }
 sub options       { @_ > 1 ? $_[0]->{options}       = $_[1] : $_[0]->{options} }
 
 sub _template_modified {

--- a/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
+++ b/lib/Mojolicious/Plugin/TtRenderer/Engine.pm
@@ -169,12 +169,11 @@ sub new {
 
     my $self = $class->SUPER::new(%params);
     $self->renderer($renderer);
-    weaken($self->{renderer});
     $self;
 }
 
-sub renderer      { @_ > 1 ? $_[0]->{renderer}      = $_[1] : $_[0]->{renderer} }
-sub ctx           { @_ > 1 ? $_[0]->{ctx}           = $_[1] : $_[0]->{ctx} }
+sub renderer      { @_ > 1 ? weaken($_[0]->{renderer} = $_[1]) : $_[0]->{renderer} }
+sub ctx           { @_ > 1 ? weaken($_[0]->{ctx}      = $_[1]) : $_[0]->{ctx} }
 sub options       { @_ > 1 ? $_[0]->{options}       = $_[1] : $_[0]->{options} }
 
 sub _template_modified {


### PR DESCRIPTION
I happened to notice that objects in the stash were going out of scope in the middle of the following hit, rather than the end of the current hit.

I think it would normally be expected that the controller is freed when the request is over.